### PR TITLE
MAINT: Add openstacksdk to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     long_description=LONG_DESCRIPTION,
     packages=find_packages(),
     python_requires=">=3.8",
-    install_requires=[],
+    install_requires=["openstacksdk", "tabulate"],
     keywords=["python, openstack"],
 )


### PR DESCRIPTION
`openstacksdk` and `tablulate` should be added to the install_requires. This is a list of packages required for a minimal installation of the package. We can leave out other packages in the requirements.txt as they are only used to configure the environment.