### PR TITLE
BUG: to_csv should gracefully handle empty results

### DIFF
--- a/openstackquery/query_blocks/query_output.py
+++ b/openstackquery/query_blocks/query_output.py
@@ -272,11 +272,9 @@ class QueryOutput:
 
     @staticmethod
     def _convert_to_csv_string(data: Union[List, Dict]) -> str:
+        if not data:
+            return ""
         output = io.StringIO()
-        if not data or not (len(data) > 0 and data[0].keys()):
-            raise RuntimeError(
-                "Error: Could not write to csv: No results found, or no properties selected to output"
-            )
         fields = data[0].keys()
         writer = csv.DictWriter(output, fieldnames=fields)
         writer.writeheader()
@@ -298,6 +296,9 @@ class QueryOutput:
         """
         results = results_container.to_props(*self.selected_props)
         results = self._validate_groups(results, groups)
+
+        if not len(results) > 0:
+            return ",".join([prop.name.lower() for prop in self.selected_props])
 
         if flatten_groups and isinstance(results, dict):
             merged_list = []

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ LONG_DESCRIPTION = (
 
 setup(
     name="openstackquery",
-    version="1.4.0",
+    version="2.0.0",
     author="STFC Cloud Team",
     author_email="<cloud-support@stfc.ac.uk>",
     description=DESCRIPTION,

--- a/tests/query_blocks/test_query_output.py
+++ b/tests/query_blocks/test_query_output.py
@@ -560,20 +560,9 @@ def test_convert_csv_to_string(instance):
     assert csv_str == expected_csv
 
 
-def test_convert_to_csv_string_raises_on_empty_data(instance):
-    """
-    Tests that _convert_to_csv_string raises RuntimeError when given an empty list.
-    """
-    with pytest.raises(RuntimeError):
-        instance._convert_to_csv_string([])
-
-
-def test_convert_to_csv_string_raises_on_empty_dict_keys(instance):
-    """
-    Tests that _convert_to_csv_string raises RuntimeError when given a list with empty dicts.
-    """
-    with pytest.raises(RuntimeError):
-        instance._convert_to_csv_string([{}])
+def test_convert_to_csv_string_returns_empty_on_empty_data(instance):
+    output = instance._convert_to_csv_string([])
+    assert output == ""
 
 
 def test_flatten_list_with_empty_data():
@@ -679,6 +668,25 @@ def test_to_csv_with_group_filtering(instance):
     assert "val1,val2" not in csv_output
 
     instance._validate_groups.assert_called_once_with(grouped_data, ["group2"])
+
+
+def test_to_csv_empty_results(instance):
+    mock_results_container = MagicMock()
+    mock_results_container.to_props.return_value = []
+
+    val = {
+        MockProperties.PROP_1,
+        MockProperties.PROP_2,
+        MockProperties.PROP_3,
+    }
+    instance.selected_props = val
+
+    result = instance.to_csv(mock_results_container)
+    mock_results_container.to_props.assert_called_once_with(*instance.selected_props)
+
+    print(result)
+
+    assert result == ",".join([prop.name.lower() for prop in instance.selected_props])
 
 
 # pylint:enable=W0212


### PR DESCRIPTION
Includes major bump

Can we merge https://github.com/stfc/openstack-query-library/pull/26 and https://github.com/stfc/openstack-query-library/pull/25 first to avoid minor bump merge conflict?